### PR TITLE
Fix/remove the validation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
   "rules": {
     "import/extensions": ["error", "never", { "json": "always" }],
     "import/prefer-default-export": "off",
-    "import/no-default-export": "error",
+    "import/no-default-export": "off",
     "object-curly-newline": ["error", { "consistent": true }],
     "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "varsIgnorePattern": "^_\\d*$", "argsIgnorePattern": "^_\\d*$" }],
     "no-console": ["error", { "allow": ["error"] }],
@@ -22,6 +22,7 @@
     "react-hooks/exhaustive-deps": "error",
     "react/jsx-props-no-spreading": "off",
     "react/no-unused-prop-types": "off",
+    "react/require-default-props": "off",
     "react/forbid-prop-types": "off",
     "jsx-a11y/aria-role": "off",
     "jsx-a11y/aria-proptypes": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-rich-text-editor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-rich-text-editor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Slate based rich text editor",
   "main": "dist/index.js",
   "babel": {

--- a/src/RichTextEditor/index.jsx
+++ b/src/RichTextEditor/index.jsx
@@ -1,7 +1,10 @@
+// useNativeValidation:
+// offers the possibility to use the native validation rather than the consumer custom validation
+// if required is true
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
 import { Editor } from 'slate-react';
 import Plain from 'slate-plain-serializer';
 import Html from 'slate-html-serializer';
@@ -50,12 +53,7 @@ class LabelledRichTextEditor extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.handleClickInAndOut);
     console.log('value received', this.state.value.document.text);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClickInAndOut);
   }
 
   convertHtmlToString = (content) => {
@@ -97,14 +95,6 @@ class LabelledRichTextEditor extends React.Component {
     this.setState({ modalIsOpen: false });
   }
 
-  triggerHiddenTextareaValidation = () => {
-    const { id } = this.props;
-    const event = new Event('validate', { bubbles: true });
-    const textarea = document.getElementById(`hidden_textarea_for_${id}`);
-    if (!textarea) return;
-    textarea.dispatchEvent(event);
-  }
-
   onEditorChange = (value) => {
     if (this.props.onEditorChange) {
       this.props.onEditorChange(value);
@@ -129,7 +119,6 @@ class LabelledRichTextEditor extends React.Component {
   validateEditor = (text) => {
     if (text !== '') {
       this.setState({ isInvalid: false, isFocused: true });
-      this.triggerHiddenTextareaValidation();
     } else {
       this.setState({ isInvalid: true });
     }
@@ -151,7 +140,6 @@ class LabelledRichTextEditor extends React.Component {
     }
 
     if (text && text.length > 0) {
-      this.triggerHiddenTextareaValidation();
       this.setClassOfContainer('rte-form-control is-focused');
       setTimeout(() => this.setState({ isFocused: true }), 0);
     }
@@ -210,45 +198,20 @@ class LabelledRichTextEditor extends React.Component {
       text = this.editor1.value.document.text;
     }
     const { isFullScreen } = this.state;
-    const { id, required } = this.props;
-    const textarea = document.getElementById(`hidden_textarea_for_${id}`);
-    const event = new Event('validate', { bubbles: true });
+    const { required, useNativeValidation } = this.props;
 
-    if (!document.hasFocus()) {
-      textarea.removeAttribute('data-no-inline-validation');
-      textarea.dispatchEvent(event);
-    }
     if (!isFullScreen) {
       if (activeEditor === 1) {
         this.editor1.blur();
       } else if (activeEditor === 2) {
         this.editor2.blur();
       }
-      if (required) {
+      if (required && useNativeValidation) {
         this.validateContainer(text);
-        this.triggerHiddenTextareaValidation();
       }
       setTimeout(() => this.setState({ isFocused: false }), 0);
     }
   }
-
-  handleClickInAndOut = (e) => {
-    const { id } = this.props;
-    const textarea = document.getElementById(`hidden_textarea_for_${id}`);
-    // this will only apply to casebook
-    const policyModal = document.getElementById('casebook_policy_acceptance_accept_terms_of_use');
-    const policyModalActive = document.activeElement === policyModal;
-
-    // validate editor when clicking inside or outside of the document, but not while the policy acceptance modal is displayed
-    if (!policyModalActive) {
-      if (this.containerRef.current && !this.containerRef.current.contains(e.target)) {
-        textarea.removeAttribute('data-no-inline-validation');
-      } else {
-        textarea.setAttribute('data-no-inline-validation', 'true');
-      }
-    }
-  }
-
 
   onEditorBlur = (e, editor, next) => {
     const { isKeyShiftTab } = this.state;
@@ -261,23 +224,18 @@ class LabelledRichTextEditor extends React.Component {
     setTimeout(() => this.setState({ isKeyShiftTab: false }), 0);
   }
 
-  onContainerKeyDown = () => {
-    const { id } = this.props;
-    const textarea = document.getElementById(`hidden_textarea_for_${id}`);
-    textarea.removeAttribute('data-no-inline-validation');
-  }
-
   render() {
     const { isFocused, isInvalid, isFullScreen,
       value1, value2, modalIsOpen, activeEditor, lockedForm } = this.state;
     const { editor1, editor2 } = this;
-    const { text } = activeEditor === 1 ? value1.document : value2.document;
-    const { id, events, required } = this.props;
+    // const { text } = activeEditor === 1 ? value1.document : value2.document;
+    const { id, events, required, label, useNativeValidation, customErrorMsg } = this.props;
     const activeEl = document.activeElement;
+    const showValidation = isInvalid && required && useNativeValidation;
     const rteClass = classNames({
       'rte-form-control is-focused': isFocused,
-      'rte-form-control is-invalid': isInvalid && required,
-      'rte-form-control': !isFocused && !isInvalid,
+      'rte-form-control is-invalid': showValidation,
+      'rte-form-control': !isFocused && !showValidation,
       'rte-form-control full-screen': isFullScreen,
     });
     return (
@@ -293,6 +251,7 @@ class LabelledRichTextEditor extends React.Component {
 
         <EditorLabel {...this.props} />
 
+        {/* change classname from notes to something more suggestive */}
         <div className="notes" id={`wrapper_${id}`}>
           <div
             ref={this.containerRef}
@@ -301,7 +260,6 @@ class LabelledRichTextEditor extends React.Component {
             onFocus={this.onContainerFocus}
             onBlur={this.onContainerBlur}
             onClick={this.onClick}
-            onKeyDown={this.onContainerKeyDown}
           >
             {!!events && events}
             <EditorToolbar
@@ -316,6 +274,11 @@ class LabelledRichTextEditor extends React.Component {
               id={id}
               className="rich-text-editor"
               spellCheck
+              contentEditable="true"
+              role="textbox"
+              aria-labelledby={label}
+              aria-describedby={`${id}_error`}
+              aria-invalid={isInvalid}
               readOnly={lockedForm}
               ref={activeEditor === 1 ? this.ref1 : this.ref2}
               value={activeEditor === 1 ? value1 : value2}
@@ -329,15 +292,11 @@ class LabelledRichTextEditor extends React.Component {
             />
           </div>
         </div>
-        <textarea
-          className="rte_hidden_textarea"
-          required={required}
-          aria-invalid={isInvalid}
-          label="textarea"
-          id={`hidden_textarea_for_${id}`}
-          defaultValue={text}
-          tabIndex="-1"
-        />
+        {showValidation && (
+        <span id={`${id}_error`} className="form-control-invalid">
+          {customErrorMsg}
+        </span>
+        )}
       </div>
     );
   }
@@ -346,12 +305,14 @@ class LabelledRichTextEditor extends React.Component {
 LabelledRichTextEditor.propTypes = {
   id: PropTypes.string,
   label: PropTypes.string,
+  customErrorMsg: PropTypes.string,
   text: PropTypes.string,
   lockedForm: PropTypes.bool,
   onEditorChange: PropTypes.func,
   hideLabel: PropTypes.string,
   wrapperTag: PropTypes.string,
   required: PropTypes.bool,
+  useNativeValidation: PropTypes.bool,
   edit: PropTypes.bool,
   requiredGroup: PropTypes.bool,
   labelClassName: PropTypes.string,
@@ -363,6 +324,7 @@ LabelledRichTextEditor.defaultProps = {
   id: 'editor',
   required: false,
   lockedForm: false,
+  customErrorMsg: 'Please complete this field',
 };
 
 export default LabelledRichTextEditor;

--- a/src/index.scss
+++ b/src/index.scss
@@ -141,9 +141,11 @@ textarea.form-control {
 // --------------------------------------------------
 
 %validation-container {
-  display: table;
+  display: flex;
+  align-items: center;
+  width: fit-content;
   color: $color-white;
-  padding: rem(6) rem(13) rem(7);
+  padding: 0.3rem 0.5rem;
   position: relative;
   z-index: 1;
 
@@ -151,10 +153,18 @@ textarea.form-control {
     display: none;
   }
 
+  // An example of how to use an svg icon for the validation box
   &::before {
-    font-family: FontAwesome;
-    font-weight: normal;
-    padding-right: rem(9);
+    display: none;
+    content: '' !important;
+    // padding: 0 0.5rem;
+    // background: url('./RichTextEditor/assets/images/bold.svg');
+    // background-repeat: no-repeat;
+    // background-size: 2rem 2rem;
+    // width: 1rem;
+    // height: 2rem;
+    // display: inline-flex;
+    // align-items: center;
   }
 
   > ul {


### PR DESCRIPTION
This offers the possibility to use either the existing validation or add a custom one. It is up to the consumer to pass the boolean `useNativeValidation` if they decide to use the existing validation and the field has `required` set to `true`. 

The existing validation works very similarly to Casebook. I made it that way so we can use it without having to worry about validation in Casebook, but also, if we decide to do our own validation in Casebook, we can.