### PR TITLE
Fix/serialisation validation issues

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -6,5 +6,6 @@
   "rules": {
     "no-empty-source": null,
     "font-family-no-missing-generic-family-keyword": null,
+    "no-descending-specificity": null,
   }
 }

--- a/src/components/RichTextEditor/components/EditorLinkModal/EditorLinkModal.jsx
+++ b/src/components/RichTextEditor/components/EditorLinkModal/EditorLinkModal.jsx
@@ -97,7 +97,7 @@ function EditorLinkModal(props) {
               <input
                 type="text"
                 id="rte-link-text"
-                className="form-control"
+                className="rte-link form-control"
                 name="rte-link-text"
                 value={inputText}
                 onChange={updateText}
@@ -108,7 +108,7 @@ function EditorLinkModal(props) {
                 aria-invalid={invalidText}
               />
               {invalidText && (
-                <span id="rte-link-text_error" className="form-control-invalid">
+                <span id="rte-link-text_error" className="rte-link form-control-invalid">
                   Please complete this field
                 </span>
               )}

--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -15,7 +15,7 @@ import EditorLinkModal from './components/EditorLinkModal/EditorLinkModal';
 
 const html = new Html({ rules });
 
-class LabelledRichTextEditor extends React.Component {
+class RichTextEditor extends React.Component {
   constructor(props) {
     super(props);
     const { edit, text, readOnly } = this.props;
@@ -43,17 +43,18 @@ class LabelledRichTextEditor extends React.Component {
     this.setState({ modalIsOpen: false });
   }
 
-  onEditorChange = (value) => {
+  onEditorChange = (value, text) => {
     const { onEditorChange } = this.props;
-    if (onEditorChange) onEditorChange(value);
+    if (onEditorChange) onEditorChange(value, text);
   }
 
   handleEditorChange = ({ value }) => {
     const { editorValue } = this.state;
+    // console.log(value);
 
     this.setState(
       { editorValue: value },
-      () => this.onEditorChange(html.serialize(editorValue)),
+      () => this.onEditorChange(html.serialize(editorValue), editorValue.document.text),
     );
   }
 
@@ -78,12 +79,14 @@ class LabelledRichTextEditor extends React.Component {
     editor.toggleMark(mark);
   }
 
-  handleContainerBlur = () => {
-    const { isFullScreen } = this.state;
+  handleContainerBlur = async () => {
+    const { isFullScreen, editorValue } = this.state;
     const { onContainerBlur } = this.props;
-    if (!isFullScreen) this.editor.blur();
-    if (onContainerBlur) {
-      onContainerBlur();
+    if (!isFullScreen) {
+      await this.editor.blur();
+      if (onContainerBlur) {
+        onContainerBlur(editorValue.document.text);
+      }
     }
   }
 
@@ -164,27 +167,22 @@ class LabelledRichTextEditor extends React.Component {
   }
 }
 
-LabelledRichTextEditor.propTypes = {
+RichTextEditor.propTypes = {
   isInvalid: PropTypes.bool,
   id: PropTypes.string,
   text: PropTypes.string,
   labelledby: PropTypes.string,
   readOnly: PropTypes.bool,
-  handleEditorChange: PropTypes.func,
-  onEditorChange: PropTypes.func,
   onContainerBlur: PropTypes.func,
-  hideLabel: PropTypes.string,
-  wrapperTag: PropTypes.string,
+  onEditorChange: PropTypes.func,
   customClassName: PropTypes.string,
-  required: PropTypes.bool,
   edit: PropTypes.bool,
   events: PropTypes.node,
 };
 
-LabelledRichTextEditor.defaultProps = {
+RichTextEditor.defaultProps = {
   id: 'editor',
-  required: false,
   readOnly: false,
 };
 
-export default LabelledRichTextEditor;
+export default RichTextEditor;

--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -50,7 +50,6 @@ class RichTextEditor extends React.Component {
 
   handleEditorChange = ({ value }) => {
     const { editorValue } = this.state;
-    // console.log(value);
 
     this.setState(
       { editorValue: value },

--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -111,12 +111,13 @@ class RichTextEditor extends React.Component {
   }
 
   render() {
-    const { isInvalid, id, events, labelledby, customClassName } = this.props;
+    const { isInvalid, id, events, labelledby } = this.props;
     const { editorValue, isFullScreen, modalIsOpen, readOnly } = this.state;
     const { editor } = this;
     const activeEl = document.activeElement;
 
     const stateClasses = classNames({
+      'is-invalid': isInvalid,
       'is-fullscreen': isFullScreen,
     });
 
@@ -134,7 +135,7 @@ class RichTextEditor extends React.Component {
           <div
             ref={this.containerRef}
             id={`${id}_editor_container`}
-            className={`rte-form-control ${customClassName}`}
+            className="rte-form-control"
             onBlur={this.handleContainerBlur}
           >
             {!!events && events}
@@ -183,7 +184,6 @@ RichTextEditor.propTypes = {
   readOnly: PropTypes.bool,
   onContainerBlur: PropTypes.func,
   onEditorChange: PropTypes.func,
-  customClassName: PropTypes.string,
   edit: PropTypes.bool,
   events: PropTypes.node,
 };

--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -59,12 +59,20 @@ class RichTextEditor extends React.Component {
   }
 
   onEditorKeyDown = (event, editor, next) => { // eslint-disable-line consistent-return
+    // trigger focused and unfocused states keyboard backward navigation
     if (event.key === 'Tab' && event.shiftKey === true) {
       this.setState({ isKeyShiftTab: true });
     }
 
+    // delete empty blocks with backspace
+    const { focus: { offset } } = editor.value.selection;
+    if (event.key === 'Backspace' && offset === 0) {
+      editor.unwrapBlock();
+    }
+
     let mark;
 
+    // handle marks
     if (IS_BOLD_HOTKEY(event)) {
       mark = 'bold';
     } else if (IS_ITALIC_HOTKEY(event)) {

--- a/src/components/RichTextEditor/link.jsx
+++ b/src/components/RichTextEditor/link.jsx
@@ -34,6 +34,16 @@ const processedHtml = (html, transfer) => {
       const u = document.createElement('u');
       u.innerHTML = span.innerHTML;
       span.parentNode.replaceChild(u, span);
+
+      // add one white space before and one after the <u/> tag because it sticks its contents to its siblings
+      const space = document.createTextNode('\u00A0');
+      u.parentNode.insertBefore(space, u.nextSibling);
+      u.parentNode.insertBefore(document.createTextNode('\u00A0'), u);
+
+      // remove white space if it is first child
+      if (!u.parentNode.firstChild.innerHTML) {
+        u.parentNode.removeChild(u.parentNode.firstChild);
+      }
     });
   }
   return body.outerHTML;

--- a/src/components/RichTextEditor/styles/index.scss
+++ b/src/components/RichTextEditor/styles/index.scss
@@ -103,11 +103,6 @@
     border-color: $color-lavender;
   }
 
-  // All invalid inputs will have this attribute
-  &.is-invalid {
-    border-color: $color-tomato;
-  }
-
   &:disabled {
     &::placeholder {
       color: $color-black-l80;
@@ -195,6 +190,12 @@
 .icon-svg {
   width: 100%;
   height: 100%;
+}
+
+.is-invalid {
+  .rte-form-control:not(:focus-within) {
+    border: $px1 solid $color-tomato;
+  }
 }
 
 .is-fullscreen {

--- a/src/components/RichTextEditor/value.json
+++ b/src/components/RichTextEditor/value.json
@@ -9,9 +9,16 @@
       "nodes": [
         {
           "object": "text",
-          "text": ""
+          "leaves": [
+              {
+                  "object": "leaf",
+                  "text": "",
+                  "marks": []
+              }
+          ]
         }
-      ]
+      ],
+      "marks": []
     }]
   }
 }


### PR DESCRIPTION
These changes fix some issues that we noticed when we brought `v1.0.0` in Casebook. These are the issues:
- text formatted with marks (bold, italic, underline) did not keep its format after saving.
- underline mark came in as a `span` in the pasted HTML markup, so it didn't show the right style: `text-decoration: underline`
- validation on the consumer side was not possible, because we did not have a callback that we could make use of on the consumer side when `onBlur` or `onChange`.