### PR TITLE
fix/deserialising

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,7 @@
     "no-underscore-dangle": "off",
     "no-unused-expressions": "off",
     "no-return-assign": 0,
+    "no-param-reassign": 0,
     "no-multi-assign": 0,
     "no-mixed-operators": 0,
     "no-plusplus": 0,

--- a/src/components/RichTextEditor/components/LinkNewWindow.jsx
+++ b/src/components/RichTextEditor/components/LinkNewWindow.jsx
@@ -5,7 +5,7 @@ const safeHost = /(^|\.)citizensadvice\.org\.uk$/;
 
 const { location } = window;
 
-function LinkNewWindow({ children, href, ...rest }) {
+function LinkNewWindow({ children, href, textNewWindow, ...rest }) {
   const rel = ['noopener'];
   const urlObject = new URL(href, location.href);
   if (new URL(location.href).origin !== urlObject.origin) {
@@ -19,7 +19,7 @@ function LinkNewWindow({ children, href, ...rest }) {
     // eslint-disable-next-line react/jsx-no-target-blank
     <a href={href} rel={rel.join(' ')} target="_blank" {...rest}>
       {children || href}
-      <span className="sr-only"> (new window)</span>
+      {!textNewWindow && <span className="sr-only"> (new window)</span>}
     </a>
   );
 }
@@ -27,6 +27,11 @@ function LinkNewWindow({ children, href, ...rest }) {
 LinkNewWindow.propTypes = {
   children: PropTypes.node,
   href: PropTypes.string.isRequired,
+  textNewWindow: PropTypes.bool,
+};
+
+LinkNewWindow.defaultProps = {
+  textNewWindow: false,
 };
 
 export default LinkNewWindow;

--- a/src/components/RichTextEditor/value.json
+++ b/src/components/RichTextEditor/value.json
@@ -18,6 +18,10 @@
           ]
         }
       ],
+      "data": {
+        "className": "",
+        "href": ""
+      },
       "marks": []
     }]
   }


### PR DESCRIPTION
There are two issues related to the deserialiser:

**1. Nested marks don't keep their format when data is retrieved**
     The serialiser handles saving data in the right format to the database, while the deserialiser handles displaying saved data. When formatting the text with multiple (nested) marks it saves the data correctly, so the serialiser works as expected, but when showing the data on the edit page or in the preview of the case note some marks are lost. This is an example of the problem:
![image](https://user-images.githubusercontent.com/40954605/84391200-8def6a80-abf0-11ea-920d-c4ab4aca42f6.png)

**2. Elements do not keep their classes when data is retrieved**
This can easily be tested with paragraph-center and paragraph-right which have the classes `rte-paragraph-center` and `rte-paragraph-right`. The elements are saved along with these classes, but when data is retrieved, elements do not keep the classes. This is a problem because the classes are what differentiates a normal paragraph from a centered or right-positioned paragraph.

